### PR TITLE
Add WITH-TERM macro for cross-thread evaluation

### DIFF
--- a/croatoan.asd
+++ b/croatoan.asd
@@ -3,7 +3,7 @@
   :author "Anton Vidovic <anton.vidovic@gmx.de>"
   :licence "MIT"
   :version "0.0.1"
-  :depends-on (:cffi :trivial-gray-streams)
+  :depends-on (:cffi :trivial-gray-streams :bordeaux-threads)
   :components 
 
   ;; Basic CFFI wrapper for libncursesw and libncurses

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -6,6 +6,8 @@
   (:export
 
    ;; croatoan.lisp
+   with-term
+   idle
    with-screen
    with-window
    with-windows
@@ -32,6 +34,8 @@
    pad
    sub-pad
    field
+   queue
+   with-term-error
    form
    form-window
    button
@@ -73,6 +77,9 @@
    newline-translation-enabled-p
    cursor-visible-p
    source-location
+   make-queue
+   queue-push
+   queue-pop
 
    ;; Predicates
    closed-p


### PR DESCRIPTION
WITH-TERM uses a thread-safe FIFO queue to queue up requests which
should be evaluated inside the terminal thread. For this to work one
has to call IDLE from inside the terminal thread to pop requests from
the FIFO and evaluate them.
When a condition is signaled while the body of WITH-TERM is evaluated,
it is handled by IDLE and put inside a WITH-TERM-ERROR which also
contains the failed form. The condition is then signaled again from
within a restart which allows skipping the failed form and continue
evaluating requests.