### PR TITLE
allowed use of 'alexandria:define-constant' with 'complex-char'.

### DIFF
--- a/src/classes.lisp
+++ b/src/classes.lisp
@@ -44,6 +44,38 @@
       (setf fgcolor (car color-pair)
             bgcolor (cadr color-pair)))))
 
+(defun complex-char= (a b)
+  (with-accessors ((simple-char-a simple-char)
+                   (bgcolor-a    bgcolor)
+                   (fgcolor-a    fgcolor)) a
+    (with-accessors ((simple-char-b simple-char)
+                     (bgcolor-b    bgcolor)
+                     (fgcolor-b    fgcolor)) b
+      (let* ((simple-char-equals-p (cond
+                                     ((null simple-char-a)
+                                      (null simple-char-b))
+                                     ((and (characterp simple-char-a)
+                                           (characterp simple-char-b))
+                                      (char= simple-char-a
+                                             simple-char-b))
+                                     ((and (integerp simple-char-a)
+                                           (integerp simple-char-b))
+                                      (= simple-char-a
+                                         simple-char-b))
+                                     (t ; mixed type or keyword
+                                      (equalp simple-char-a
+                                              simple-char-b)))))
+        (and simple-char-equals-p
+             (equalp fgcolor-a
+                     fgcolor-b)
+             (equalp fgcolor-a
+                     fgcolor-b))))))
+
+(defmethod make-load-form ((object complex-char) &optional environment)
+  (make-load-form-saving-slots object
+                               :slot-names '(simple-char attributes color-pair)
+                               :environment environment))
+
 (defclass complex-string ()
   ((complex-char-array
     :initarg       :complex-char-array

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -78,6 +78,7 @@
 
    ;; Predicates
    closed-p
+   complex-char=
    
    ;; menu
    items


### PR DESCRIPTION
Hi!

I noticed an error like

``` text
 [...]    don't know how to dump   (default MAKE-LOAD-FORM method called) [...]
```
 when trying to use a form like that:

``` common-lisp
(alexandria:define-constant +bg+ (make-instance 'complex-char
                                                :simple-char #\Space
                                                :color-pair  '(:yellow :blue)
                                                :attributes  nil)
  :test #'complex-char=)
```
Given that `alexandria` seems to be a widely used library i thought would be a good idea to allow to define constant of  `complex-char` with this facility.

As a bonus probably the function `complex-char=` could save some times to developers :)

Please consider merging.
Bye!
C.