### PR TITLE
- added return of unknown "wide event"  to the user-code instead of nil in 'get-wide-event'

### DIFF
--- a/src/get_wch.lisp
+++ b/src/get_wch.lisp
@@ -16,6 +16,8 @@ The window from which the char is read is automatically refreshed."
         (values (cffi:mem-ref ptr 'wint_t) t)
         (values (cffi:mem-ref ptr 'wint_t) nil))))
 
+(defparameter *unknown-event-as-nil* t)
+
 (defun get-wide-event (window)
   "Return a single user input event.
 
@@ -29,8 +31,12 @@ If input-blocking is nil for the window, return nil if no key was typed."
       ((= ch 0) nil)
       (function-key-p
        (let ((ev (function-key ch)))
-         (if (eq ev :mouse)
-             (multiple-value-bind (mev y x) (get-mouse-event)
-               (values mev y x)) ; returns 3 values, see mouse.lisp
-             ev)))
+         (cond
+           ((eq ev :mouse)
+            (multiple-value-bind (mev y x) (get-mouse-event)
+              (values mev y x))) ; returns 3 values, see mouse.lisp
+         ((and (null ev)
+               (null *unknown-event-as-nil*))
+          ch)
+         (t ev))))
       (t (code-char ch)))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -197,6 +197,7 @@
    get-event
 
    ;; get_wch / get (or push back) a wide (multi-byte) character from curses terminal keyboard
+   *unknown-event-as-nil*
    get-wide-char
    get-wide-event
 


### PR DESCRIPTION
  Hi!  

  'get-wide-event'  return  nil   if  an  event  is   not  present  in
  '*key-alist*' i  think this could  be changed to return  the unknown
  event as  int and letting  the user-code  deal with it  instead of
  giving the impression that the key fired no event.

  This could be useful even for debugging purposes, i guess.

  the  return   type  can  be   changed  using  a   special  variable:
  '*unknown-event-as-nil*' that  if non-nil (the default)  use the old
  behaviour.