### PR TITLE
Used the excellent cffi-groveler to generate locale constants 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Copyright (c) 2012-2019,2020 Anton Vidovic <anton.vidovic@gmx.de>
 
 Portions Copyright (c) 2018 Daniel Vedder <d.vedder@web.de>
 Portions Copyright (c) 2019 D4ryus <d4ryus@teknik.io>
-Portions Copyright (c) 2019-2020 cage2 <github.com/cage2>
+Portions Copyright (c) 2019-2020 cage2 <notabug.org/cage>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/croatoan-ncurses.asd
+++ b/croatoan-ncurses.asd
@@ -3,11 +3,13 @@
   :author "Anton Vidovic <anton.vidovic@gmx.de>"
   :licence "MIT"
   :version "0.0.1"
+  :defsystem-depends-on ("cffi-grovel")
   :depends-on (:cffi)
   :pathname "ncurses/"
   :components
 
   ((:file "package")
+   (:cffi-grovel-file "grovel")
    (:file "ncurses")          ; library file names, ncurses file types
 
    (:file "addch")            ; add a character (with attributes) to a curses window, then advance the cursor

--- a/ncurses/grovel.lisp
+++ b/ncurses/grovel.lisp
@@ -1,0 +1,29 @@
+(in-package :de.anvi.ncurses)
+
+(include "locale.h")
+
+(constant (+lc-address+        "LC_ADDRESS"))
+
+(constant (+lc-all+            "LC_ALL"))
+
+(constant (+lc-collate+        "LC_COLLATE"))
+
+(constant (+lc-ctype+          "LC_CTYPE"))
+
+(constant (+lc-identification+ "LC_IDENTIFICATION"))
+
+(constant (+lc-measurement+    "LC_MEASUREMENT"))
+
+(constant (+lc-messages+       "LC_MESSAGES"))
+
+(constant (+lc-monetary+       "LC_MONETARY"))
+
+(constant (+lc-name+           "LC_NAME"))
+
+(constant (+lc-numeric+        "LC_NUMERIC"))
+
+(constant (+lc-paper+          "LC_PAPER"))
+
+(constant (+lc-telephone+      "LC_TELEPHONE"))
+
+(constant (+lc-time+           "LC_TIME"))

--- a/ncurses/libc.lisp
+++ b/ncurses/libc.lisp
@@ -20,17 +20,3 @@
 
 ;; (cffi:defcvar ("LC_ALL" +LC-ALL+ :read-only t) :int)
 ;; ERROR: Trying to access undefined foreign variable "LC_ALL".
-
-(defconstant +LC-CTYPE+           0)
-(defconstant +LC-NUMERIC+         1)
-(defconstant +LC-TIME+            2)
-(defconstant +LC-COLLATE+         3)
-(defconstant +LC-MONETARY+        4)
-(defconstant +LC-MESSAGES+        5)
-(defconstant +LC-ALL+             6)
-(defconstant +LC-PAPER+           7)
-(defconstant +LC-NAME+            8)
-(defconstant +LC-ADDRESS+         9)
-(defconstant +LC-TELEPHONE+      10)
-(defconstant +LC-MEASUREMENT+    11)
-(defconstant +LC-IDENTIFICATION+ 12)


### PR DESCRIPTION
Hi!

I have thought that would be a good idea to use cffi-groveller intead of hardcoded valies for all "LC_*" POSIX constants as the latter ~metod~ method could be not portable across different operating systems.

Also i have downcased constant names as some implementation (allegro if I remember correctly) are able to discriminate string case.

Bye!
C.