### PR TITLE
Added 'concat-complex-string' method specialized on sequence complex-string

### DIFF
--- a/src/character.lisp
+++ b/src/character.lisp
@@ -350,9 +350,9 @@ color of the last element of `a'."
 (defmethod concat-complex-string ((a sequence) (b complex-string)
                                   &key (color-attributes-contagion t))
   "Return a  complex string  that is the  results of  concatenating of
-`a'    (a `complex-string') and `b' (a string). If
-`color-attributes-contagion' is non nil `b' will inherit all the attributes and
-color of the last element of `a'."
+`a'    (a `string') and `b' (a `complex-string'). If
+`color-attributes-contagion' is non nil `a' will inherit all the attributes and
+color of the last element of `b'."
   (with-accessors ((inner-array-b complex-char-array)) b
     (multiple-value-bind (new-attributes new-bg new-fg)
         (complex-string-first-char-attributes b)

--- a/src/character.lisp
+++ b/src/character.lisp
@@ -352,7 +352,7 @@ color of the last element of `a'."
   "Return a  complex string  that is the  results of  concatenating of
 `a'    (a `string') and `b' (a `complex-string'). If
 `color-attributes-contagion' is non nil `a' will inherit all the attributes and
-color of the last element of `b'."
+color of the first element of `b'."
   (with-accessors ((inner-array-b complex-char-array)) b
     (multiple-value-bind (new-attributes new-bg new-fg)
         (complex-string-first-char-attributes b)


### PR DESCRIPTION
Hi @McParen !

I just realized `concat-complex-string` does not permits to append  a  a `complex-string` to a `string`.

I just guessed was a good idea to add this missing method. :-) 

Bye!
C.