### PR TITLE
Add labels to work with check boxes.

### DIFF
--- a/src/form.lisp
+++ b/src/form.lisp
@@ -232,11 +232,10 @@ content position = widget position + border + padding"
 
 ;; TODO: for a checkbox, we need a style for checked and unchecked
 (defmethod draw ((checkbox checkbox))
-  (with-accessors ((pos widget-position) (name name) (win window) (selectedp selectedp) (style style)
-                   (checkedp checkedp)) checkbox
+  (with-accessors ((pos widget-position) (name name) (title tile) (win window) (selectedp selectedp) (style style) (checkedp checkedp)) checkbox
     (goto win pos)
     (let* ((fg-style (if selectedp (getf style :selected-foreground) (getf style :foreground))))
-      (add-string win (format nil "[~A]" (if checkedp "X" "_")) :style fg-style)
+      (add-string win (format nil "[~A]" (if checkedp "X" "_") (if title title name )) :style fg-style)
       (update-cursor-position checkbox))))
 
 (defmethod draw ((form form))


### PR DESCRIPTION
Gday,

I'd like to include a fix for the checkboxes in forms not drawing the 'Title' element as per the test t16g.


The particular example is:

(cb1 (make-instance 'checkbox :name :c1 :title "Employed" :position (list 9 20)))

I think that the fix would allow the word "Employed" to be shown.

I am using the checkboxes in my code, as per below:

(make-instance 'checkbox
                            :name :checkbox-1
                            :title "IM CHECKABLE"
                            :position '(8 12)))

With my change the checkbox shows.    I'd like to also point out that my testing was mostly done against the version pushed to quicklisp ( croatoan-20220331-git ) so if you have fixed this another way, thats cool too.

Nice work on the forms improvements in the recent days.

